### PR TITLE
image_id in the accounting record

### DIFF
--- a/caso/extract/nova.py
+++ b/caso/extract/nova.py
@@ -95,9 +95,12 @@ class OpenStackExtractor(base.BaseExtractor):
         for server in servers:
             status = self.vm_status(server.status)
             image_id = None
-            if server.image and server.image['id'] in images:
+            if server.image:
                 image = images.get(server.image['id'])
-                image_id = image.get("vmcatcher_event_ad_mpuri", None)
+                image_id = server.image['id']
+                if image:
+                    if image.get("vmcatcher_event_ad_mpuri", None) is not None:
+                        image_id = image.get("vmcatcher_event_ad_mpuri", None)
 
             flavor = flavors.get(server.flavor["id"])
             if flavor:
@@ -116,9 +119,6 @@ class OpenStackExtractor(base.BaseExtractor):
                               "and benchmark_value_key in the configuration "
                               "file or set the correct properties in the "
                               "flavor.")
-
-            if image_id is None:
-                image_id = server.image['id']
 
             r = record.CloudRecord(server.id,
                                    CONF.site_name,

--- a/doc/source/configuration.rst
+++ b/doc/source/configuration.rst
@@ -28,7 +28,7 @@ the flavor properties and configure caso to retrieve this information. There
 are two different values that need to be added to the flavor:
 
 * The benchmark name, indicated with the ``benchmark_name`` flavor property.
-* The benchmark value, indicated with the ``benchkark_value`` flavor property.
+* The benchmark value, indicated with the ``benchmark_value`` flavor property.
 
 So, if you are using HEPSPEC06 and the benchmark value is ``99`` for the flavor
 ``m1.foo`` you should set this as follows::


### PR DESCRIPTION
in order
1 - image_id = None  (if server image id doesn't exist)
2 - image_id = server image id (if image didn't come from appdb)
3 - image_id = vmcatcher_event_ad_mpuri

also small fix in the configuration.rst